### PR TITLE
Fix missing egg component crash, Fix Dragon Egg Dupe

### DIFF
--- a/src/main/java/com/github/kay9/dragonmounts/dragon/DMLEggBlock.java
+++ b/src/main/java/com/github/kay9/dragonmounts/dragon/DMLEggBlock.java
@@ -126,7 +126,7 @@ public class DMLEggBlock extends DragonEggBlock implements EntityBlock
         public Component getName(ItemStack stack)
         {
             var tag = stack.getTag();
-            if (tag == null || tag.contains(DATA_ITEM_NAME))
+            if (tag != null && tag.contains(DATA_ITEM_NAME))
                 return Component.translatable(tag.getString(DATA_ITEM_NAME));
             return super.getName(stack);
         }

--- a/src/main/java/com/github/kay9/dragonmounts/dragon/DMLEggBlock.java
+++ b/src/main/java/com/github/kay9/dragonmounts/dragon/DMLEggBlock.java
@@ -75,7 +75,6 @@ public class DMLEggBlock extends DragonEggBlock implements EntityBlock
         if (entity instanceof Entity e)
         {
             startHatching(e.getBreed(level.registryAccess()), e.getHatchTime(), level, pos);
-            level.setBlock(pos, Blocks.AIR.defaultBlockState(), Block.UPDATE_CLIENTS);
             return InteractionResult.sidedSuccess(level.isClientSide);
         }
         return InteractionResult.PASS;
@@ -109,6 +108,7 @@ public class DMLEggBlock extends DragonEggBlock implements EntityBlock
             egg.setHatchTime(hatchTime);
             egg.setPos(pos.getX() + 0.5d, pos.getY() + 0.1d, pos.getZ() + 0.5d);
             level.addFreshEntity(egg);
+            level.setBlock(pos, Blocks.AIR.defaultBlockState(), Block.UPDATE_CLIENTS); // Clean up original dragon egg
         }
     }
 

--- a/src/main/resources/assets/dragonmounts/lang/en_us.json
+++ b/src/main/resources/assets/dragonmounts/lang/en_us.json
@@ -19,6 +19,7 @@
   "item.dragonmounts.spawn_egg.dragonmounts.nether": "Nether Dragon Spawn Egg",
   "item.dragonmounts.spawn_egg.dragonmounts.water": "Water Dragon Spawn Egg",
 
+  "block.dragonmounts.dragon_egg": "Dragon Spawn Egg",
   "block.dragonmounts.dragon_egg.remaining_time": "Hatches in %s seconds.",
   "block.dragonmounts.dragon_egg.change_breeds": "Creative mode: Interacting with a dragon will change it's breed to this egg's breed.",
 

--- a/src/main/resources/assets/dragonmounts/lang/ja_jp.json
+++ b/src/main/resources/assets/dragonmounts/lang/ja_jp.json
@@ -19,6 +19,7 @@
   "item.dragonmounts.spawn_egg.dragonmounts.nether": "ネザードラゴンのスポーンエッグ",
   "item.dragonmounts.spawn_egg.dragonmounts.water": "ウォータードラゴンのスポーンエッグ",
 
+  "block.dragonmounts.dragon_egg": "ドラゴンのスポーンエッグ",
   "block.dragonmounts.dragon_egg.remaining_time": "%s秒以内に孵化します。",
   "block.dragonmounts.dragon_egg.change_breeds": "クリエイティブモード：ドラゴンと対話することでドラゴンの品種がこの卵の品種に代わります。",
 

--- a/src/main/resources/assets/dragonmounts/lang/uk_ua.json
+++ b/src/main/resources/assets/dragonmounts/lang/uk_ua.json
@@ -27,6 +27,7 @@
   "block.dragonmounts.dragon_egg.hatch_stage.2": "Здається, воно ворушиться час від часу. Можливо, воно близьке до вилуплення.",
   "block.dragonmounts.dragon_egg.hatch_stage.3": "Чути звуки, що долинають зсередини! Воно скоро вилупиться!",
   "block.dragonmounts.dragon_egg.remaining_time": "Вилупиться через %s секунд.",
+  "block.dragonmounts.dragon_egg": "Яйце виклику дракона",
 
   "block.dragonmounts.dragon_egg.dragonmounts.aether": "Яйце дракона Етеру",
   "block.dragonmounts.dragon_egg.dragonmounts.fire": "Яйце вогневого дракона",


### PR DESCRIPTION
This pr fixes a crash in 1.19.2 caused by eggs being created without name tags such as when dropping on a torch and breaking. This would cause an egg with invalid data to be created and when hovering over the item clients will crash. Translations have been added to fix the untranslated name showing as the item name as well. I can confirm English is correct, Japanese / Ukrainian translations were verified against Google Translate.

This pr also restores the call in when an egg starts hatching that removed the original block. This was the behavior in 1.16 but at some point was handled outside the method. This meant that Vanilla Dragon Eggs could be duplicated.
